### PR TITLE
Research in how to query the last readthrough comments

### DIFF
--- a/bookwyrm/templates/user/statistics.html
+++ b/bookwyrm/templates/user/statistics.html
@@ -15,12 +15,21 @@
 {% if is_self %}
 <div>
     <div class="is-mobile field is-grouped">
-    This content is subject to change in subsequent Pull Requests.
-    {% for shelf in shelves %}
-        {% for book in shelf.books %}
-            Book was published in {{ book.published_date.year }}
-        {% endfor %}
-    {% endfor %}
+        <ol>
+            {% for shelf in shelves %}
+                In shelf {{ shelf.name }}:
+                {% if shelf.books.count %}
+                    {% for book in shelf.books %}
+                        <li>
+                            {{ book.title }} was published in {{ book.published_date.year }}.
+                            {% if book.latest_readthrough %}
+                                Last readthrough: {{ book.latest_readthrough.finish_date }}
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </ol>
     </div>
 </div>
 {% endif %}


### PR DESCRIPTION
In order to iterate on https://github.com/bookwyrm-social/bookwyrm/pull/2102 I need to figure out how to get a list of reading updates. Therefore I looked into the ReadThrough model:

https://github.com/bookwyrm-social/bookwyrm/blob/569e5400fe1c6c8d5923453adc1ad21b2e8adb2f/bookwyrm/models/readthrough.py#L17-L31

It turns out that there is already a helper method on the book model, that exposes the last update as property:

https://github.com/bookwyrm-social/bookwyrm/blob/569e5400fe1c6c8d5923453adc1ad21b2e8adb2f/bookwyrm/models/book.py#L169-L172

Now, the question is how to handle progress by page vs. percent?
Do we want to consider all readthrough comments? Just the one for start and finish date?

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>